### PR TITLE
Fix comparison operator for new_range check

### DIFF
--- a/sdml-core/src/model/members/cardinality.rs
+++ b/sdml-core/src/model/members/cardinality.rs
@@ -386,7 +386,7 @@ impl CardinalityRange {
 
     pub const fn new_range(min: u32, max: u32) -> Self {
         assert!(
-            max > 0 && max > min,
+            max > 0 && max >= min,
             "Zero, or negative, cardinality range is not allowed."
         );
         Self {


### PR DESCRIPTION
This was failing to load any SDML file which has cardinality written in a form like `{1..1}` which is not ideal, but valid.